### PR TITLE
Remove Network Algorithms Midterm, Make Coefs 1.5 for PW, and EXAM

### DIFF
--- a/templates/app/semester_2/cs_average_s2.html
+++ b/templates/app/semester_2/cs_average_s2.html
@@ -89,7 +89,7 @@
                     <input type="number" step="0.01" id="computer-architecture-pw" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
                 </div>
                 <div class="space-y-2">
-                    <label for="heat-transfer-second-exam" class="block text-lg font-medium">Computer Architecture Midterm</label>
+                    <label for="heat-transfer-second-exam" class="block text-lg font-medium">Computer Architecture Quiz??</label>
                     <input type="number" step="0.01" id="computer-architecture-midterm" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
                 </div>
                 <div class="space-y-2">
@@ -140,10 +140,10 @@
                     <label for="process-diagram-exam" class="block text-lg font-medium">Network Algorithms PW</label>
                     <input type="number" step="0.01" id="network-algorithms-pw" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
                 </div>
-                <div class="space-y-2">
+                <!-- <div class="space-y-2">
                     <label for="process-diagram-exam" class="block text-lg font-medium">Network Algorithms Midterm</label>
                     <input type="number" step="0.01" id="network-algorithms-midterm" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
-                </div>
+                </div> -->
                 <div class="space-y-2">
                     <label for="process-diagram-exam" class="block text-lg font-medium">Network Algorithms Exam</label>
                     <input type="number" step="0.01" id="network-algorithms-exam" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
@@ -189,7 +189,7 @@
                 'cryptography-project': parseFloat(document.getElementById('cryptography-project').value),
                 'cryptography-exam': parseFloat(document.getElementById('cryptography-exam').value),
                 'network-algorithms-pw': parseFloat(document.getElementById('network-algorithms-pw').value),
-                'network-algorithms-midterm': parseFloat(document.getElementById('network-algorithms-midterm').value),
+                // 'network-algorithms-midterm': parseFloat(document.getElementById('network-algorithms-midterm').value),
                 'network-algorithms-exam': parseFloat(document.getElementById('network-algorithms-exam').value),
             };
     
@@ -221,8 +221,8 @@
                 (scores['cryptography-pw'] * (15 / 5) * (1/4)) +
                 (scores['cryptography-project'] * (15 / 5) * (1/4)) +
                 (scores['cryptography-exam'] * (15 / 5) * (1/2)) +
-                (scores['network-algorithms-pw'] * (15 / 5) * (1/4)) +
-                (scores['network-algorithms-midterm'] * (15 / 5) * (1/4)) +
+                (scores['network-algorithms-pw'] * (15 / 5) * (1/2)) +
+                // (scores['network-algorithms-midterm'] * (15 / 5) * (1/4)) +
                 (scores['network-algorithms-exam'] * (15 / 5)* (1/2));
         
             
@@ -324,9 +324,9 @@
                 if (scores['network-algorithms-pw'] !== undefined) {
                     document.getElementById('network-algorithms-pw').value = scores['network-algorithms-pw'];
                 }
-                if (scores['network-algorithms-midterm'] !== undefined) {
-                    document.getElementById('network-algorithms-midterm').value = scores['network-algorithms-midterm'];
-                }
+                // if (scores['network-algorithms-midterm'] !== undefined) {
+                //     document.getElementById('network-algorithms-midterm').value = scores['network-algorithms-midterm'];
+                // }
                 if (scores['network-algorithms-exam'] !== undefined) {
                     document.getElementById('network-algorithms-exam').value = scores['network-algorithms-exam'];
                 }


### PR DESCRIPTION
This pull request makes changes to the `templates/app/semester_2/cs_average_s2.html` file to update the handling of the "Network Algorithms Midterm" field, including its removal from the user interface and calculations. Additionally, a label for "Computer Architecture" was updated. Below are the most important changes grouped by theme:

### Removal of "Network Algorithms Midterm" Field:

* Commented out the "Network Algorithms Midterm" input field in the HTML template, effectively removing it from the user interface. (`[templates/app/semester_2/cs_average_s2.htmlL143-R146](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L143-R146)`)
* Removed the "Network Algorithms Midterm" field from the scores object in the JavaScript code by commenting out the associated line. (`[templates/app/semester_2/cs_average_s2.htmlL192-R192](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L192-R192)`)
* Adjusted the weight calculation for "Network Algorithms" by redistributing the weight previously assigned to the midterm across other components. (`[templates/app/semester_2/cs_average_s2.htmlL224-R225](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L224-R225)`)
* Commented out the logic that pre-populates the "Network Algorithms Midterm" field in the JavaScript code. (`[templates/app/semester_2/cs_average_s2.htmlL327-R329](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L327-R329)`)

### Update to "Computer Architecture" Label:

* Changed the label text for "Computer Architecture Midterm" to "Computer Architecture Quiz??" in the HTML template. (`[templates/app/semester_2/cs_average_s2.htmlL92-R92](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L92-R92)`)



Closes #19 