### PR TITLE
Fix Computer Architecture Fields

### DIFF
--- a/templates/app/semester_2/cs_average_s2.html
+++ b/templates/app/semester_2/cs_average_s2.html
@@ -85,15 +85,11 @@
             <div>
                 <h2 class="text-2xl font-semibold mb-4 text-center text-green-400">Computer Science</h2>
                 <div class="space-y-2">
-                    <label for="heat-transfer-first-exam" class="block text-lg font-medium">Computer Architecture PW</label>
-                    <input type="number" step="0.01" id="computer-architecture-pw" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
-                </div>
-                <div class="space-y-2">
-                    <label for="heat-transfer-second-exam" class="block text-lg font-medium">Computer Architecture Quiz??</label>
+                    <label for="heat-transfer-second-exam" class="block text-lg font-medium">Computer Architecture Midterm Exam</label>
                     <input type="number" step="0.01" id="computer-architecture-midterm" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
                 </div>
                 <div class="space-y-2">
-                    <label for="process-diagram-homework" class="block text-lg font-medium">Computer Architecture Exam</label>
+                    <label for="process-diagram-homework" class="block text-lg font-medium">Computer Architecture Final Exam</label>
                     <input type="number" step="0.01" id="computer-architecture-exam" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
                 </div>
                 <div class="space-y-2">
@@ -175,7 +171,7 @@
                 'waves-core': parseFloat(document.getElementById('waves-core').value),
                 'optics-score': parseFloat(document.getElementById('optics-score').value),
                 'physics-lab': parseFloat(document.getElementById('physics-lab').value),
-                'computer-architecture-pw': parseFloat(document.getElementById('computer-architecture-pw').value),
+                // 'computer-architecture-pw': parseFloat(document.getElementById('computer-architecture-pw').value),
                 'computer-architecture-midterm': parseFloat(document.getElementById('computer-architecture-midterm').value),
                 'computer-architecture-exam': parseFloat(document.getElementById('computer-architecture-exam').value),
                 'databases-participation': parseFloat(document.getElementById('databases-participation').value),
@@ -208,9 +204,9 @@
                 (scores['waves-core'] * (6 / 2) * (1/3)) + 
                 (scores['optics-score'] * (6 / 2) * (1/3)) + 
                 (scores['physics-lab'] * (6 / 2) * 1) + 
-                (scores['computer-architecture-pw'] * (15 / 5) * 1/4) + 
+                // (scores['computer-architecture-pw'] * (15 / 5) * 1/4) + 
                 (scores['computer-architecture-midterm'] * (15 / 5) * 1/4) + 
-                (scores['computer-architecture-exam'] * (15 / 5) * (1/2)) + 
+                (scores['computer-architecture-exam'] * (15 / 5) * (3/4)) + 
                 (scores['databases-participation'] * (15 / 5) * (1/10)) + 
                 (scores['databases-pw'] * (15 / 5) * (2/10)) + 
                 (scores['databases-project'] * (15 / 5) * (2/10)) + 
@@ -225,7 +221,7 @@
                 // (scores['network-algorithms-midterm'] * (15 / 5) * (1/4)) +
                 (scores['network-algorithms-exam'] * (15 / 5)* (1/2));
         
-            
+            console.log('Weighted Sum:', weightedSum);
             const totalCoefficients = 30;
             const weightedAverage = weightedSum / totalCoefficients;
     
@@ -282,9 +278,9 @@
                 if (scores['physics-lab'] !== undefined) {
                     document.getElementById('physics-lab').value = scores['physics-lab'];
                 }
-                if (scores['computer-architecture-pw'] !== undefined) {
-                    document.getElementById('computer-architecture-pw').value = scores['computer-architecture-pw'];
-                }
+                // if (scores['computer-architecture-pw'] !== undefined) {
+                //     document.getElementById('computer-architecture-pw').value = scores['computer-architecture-pw'];
+                // }
                 if (scores['computer-architecture-midterm'] !== undefined) {
                     document.getElementById('computer-architecture-midterm').value = scores['computer-architecture-midterm'];
                 }


### PR DESCRIPTION
This pull request makes updates to the `cs_average_s2.html` template to improve clarity and functionality by renaming fields, adjusting weight calculations, and adding debug logging. The changes primarily focus on the "Computer Architecture" section and its associated calculations.

### Updates to field names and labels:
* Renamed `computer-architecture-pw` to `computer-architecture-midterm` and updated its label to "Computer Architecture Midterm Exam."
* Renamed `computer-architecture-exam` label to "Computer Architecture Final Exam" for better clarity.

### Adjustments to calculations:
* Commented out the `computer-architecture-pw` field and its weight calculation, effectively removing it from the weighted average formula. [[1]](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L178-R174) [[2]](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L211-R209)
* Adjusted the weight of `computer-architecture-exam` in the formula from `(1/2)` to `(3/4)` for more accurate grading.

### Debugging enhancements:
* Added a `console.log` statement to log the `weightedSum` for debugging purposes.

### Cleanup of unused fields:
* Commented out the logic for handling `computer-architecture-pw` in the input population script, as it is no longer in use.