### PR TITLE
Fix Computer Architecture Fields

### DIFF
--- a/templates/app/semester_2/cs_average_s2.html
+++ b/templates/app/semester_2/cs_average_s2.html
@@ -85,6 +85,10 @@
             <div>
                 <h2 class="text-2xl font-semibold mb-4 text-center text-green-400">Computer Science</h2>
                 <div class="space-y-2">
+                    <label for="heat-transfer-second-exam" class="block text-lg font-medium">Computer Architecture PW</label>
+                    <input type="number" step="0.01" id="computer-architecture-pw" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
+                </div>
+                <div class="space-y-2">
                     <label for="heat-transfer-second-exam" class="block text-lg font-medium">Computer Architecture Midterm Exam</label>
                     <input type="number" step="0.01" id="computer-architecture-midterm" class="block w-full mb-2 p-2 border rounded-lg bg-gray-700 text-white" required>
                 </div>
@@ -171,7 +175,7 @@
                 'waves-core': parseFloat(document.getElementById('waves-core').value),
                 'optics-score': parseFloat(document.getElementById('optics-score').value),
                 'physics-lab': parseFloat(document.getElementById('physics-lab').value),
-                // 'computer-architecture-pw': parseFloat(document.getElementById('computer-architecture-pw').value),
+                'computer-architecture-pw': parseFloat(document.getElementById('computer-architecture-pw').value),
                 'computer-architecture-midterm': parseFloat(document.getElementById('computer-architecture-midterm').value),
                 'computer-architecture-exam': parseFloat(document.getElementById('computer-architecture-exam').value),
                 'databases-participation': parseFloat(document.getElementById('databases-participation').value),
@@ -204,9 +208,9 @@
                 (scores['waves-core'] * (6 / 2) * (1/3)) + 
                 (scores['optics-score'] * (6 / 2) * (1/3)) + 
                 (scores['physics-lab'] * (6 / 2) * 1) + 
-                // (scores['computer-architecture-pw'] * (15 / 5) * 1/4) + 
-                (scores['computer-architecture-midterm'] * (15 / 5) * 1/4) + 
-                (scores['computer-architecture-exam'] * (15 / 5) * (3/4)) + 
+                (scores['computer-architecture-pw'] * (15 / 5) * 1/2) + 
+                (scores['computer-architecture-midterm'] * (15 / 5) * 1/8) + 
+                (scores['computer-architecture-exam'] * (15 / 5) * (3/8)) + 
                 (scores['databases-participation'] * (15 / 5) * (1/10)) + 
                 (scores['databases-pw'] * (15 / 5) * (2/10)) + 
                 (scores['databases-project'] * (15 / 5) * (2/10)) + 
@@ -278,9 +282,9 @@
                 if (scores['physics-lab'] !== undefined) {
                     document.getElementById('physics-lab').value = scores['physics-lab'];
                 }
-                // if (scores['computer-architecture-pw'] !== undefined) {
-                //     document.getElementById('computer-architecture-pw').value = scores['computer-architecture-pw'];
-                // }
+                if (scores['computer-architecture-pw'] !== undefined) {
+                    document.getElementById('computer-architecture-pw').value = scores['computer-architecture-pw'];
+                }
                 if (scores['computer-architecture-midterm'] !== undefined) {
                     document.getElementById('computer-architecture-midterm').value = scores['computer-architecture-midterm'];
                 }


### PR DESCRIPTION
This pull request updates the `cs_average_s2.html` template to fully integrate the "Computer Architecture PW" input field into the semester 2 average calculation. The changes include adding the input field, enabling its value to be processed in the calculations, and adjusting the weight distribution for the "Computer Architecture" scores.

### New Feature Integration:
* Added a new input field for "Computer Architecture PW" with appropriate styling and attributes. (`templates/app/semester_2/cs_average_s2.html`, [templates/app/semester_2/cs_average_s2.htmlR87-R90](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594R87-R90))

### Logic Updates:
* Enabled the processing of the "Computer Architecture PW" score by uncommenting and modifying its inclusion in the `scores` object. (`templates/app/semester_2/cs_average_s2.html`, [templates/app/semester_2/cs_average_s2.htmlL174-R178](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L174-R178))
* Adjusted the weight distribution for "Computer Architecture" scores in the average calculation formula:
  - "PW" now contributes 1/2.
  - "Midterm" contributes 1/8.
  - "Exam" contributes 3/8. (`templates/app/semester_2/cs_average_s2.html`, [templates/app/semester_2/cs_average_s2.htmlL207-R213](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L207-R213))

### Data Persistence:
* Ensured that the "Computer Architecture PW" value is retained and displayed correctly when scores are reloaded. (`templates/app/semester_2/cs_average_s2.html`, [templates/app/semester_2/cs_average_s2.htmlL281-R287](diffhunk://#diff-6bfef8135ad909ac81a3ed356c17b0d6ef3afcd4b41cef7b867b4f494bd90594L281-R287))